### PR TITLE
change nested default to initial_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## v0.0.11
+
+- Nested and array attributes now take `initial_value` rather than `default`
+- Do not set a default value using a proc if the getter returns anything but nil
+
 ## v0.0.10
 
 - Changed the initialization order so default values are set after the attributes are set

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    strong_attributes (0.0.10)
+    strong_attributes (0.0.11)
       activemodel (>= 6.1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ class Form
 end
 ```
 
-## Initalizing
+## Initializing
 
-The form is intended to be initalized with user submitted data. Only defined attributes will be set.
+The form is intended to be initialized with user submitted data. Only defined attributes will be set.
 
 ```ruby
 class Form
@@ -334,8 +334,27 @@ form.person = { _destroy: true }
 form.person # => nil
 ```
 
+### Initial values
+
+Initial values can be set using a proc, or symbol referring to a method.
+
+```ruby
+class Form
+  include StrongAttributes
+
+  nested_attributes :person, initial_value: -> { { name: "Bob" } } do
+    attribute :name, :string
+    attribute :date_of_birth, :date
+  end  
+end
+
+form = Form.new(person: { date_of_birth: "1980-01-01" } })
+form.person # => <Person date_of_birth=1980-01-01 name="Bob">
+```
+
 ### Options
 
+- **`initial_value`**: The initial value, can also be be a proc or a symbol
 - **`allow_destroy`** (`boolean`): if `true` if a `_destroy: true` key is passed then an existing record will be set to `nil`, or `mark_for_destruction`, will be called if the object responds to that method.
 - **`reject_if`** (`proc`): if the proc returns true the update will be rejected/
 - **`replace`** (`boolean`): if `true` an update will replace the existing record rather than merging values in.
@@ -433,8 +452,27 @@ form.people = [id: "1", _destroy: true]
 form.people # => [<Person id=2 name="Harry">]
 ```
 
+### Initial values
+
+Initial values can be set using a proc, or symbol referring to a method.
+
+```ruby
+class Form
+  include StrongAttributes
+
+  nested_array_attributes :people, initial_value: -> { [name: "Frank"] } do
+    attribute :name, :string
+    attribute :date_of_birth, :date
+  end  
+end
+
+form = Form.new({ people: [name: "Bob"] })
+form.people # => [<Person name="Bob">, <Person name="Frank">]
+```
+
 ### Options
 
+- **`initial_value`**: The initial value, can also be be a proc or a symbol
 - **`allow_destroy`** (`boolean`): if `true` if a `_destroy: true` key is passed then an existing record will either be removed, or `mark_for_destruction`, will be called if the object responds to that method.
 - **`reject_if`** (`proc`): If the proc returns true the update will be rejected
 - **`limit`** (`Integer`): If provided, raise a `TooManyRecords` error if the limit is exceeded

--- a/lib/strong_attributes/nested_attributes.rb
+++ b/lib/strong_attributes/nested_attributes.rb
@@ -84,13 +84,13 @@ module StrongAttributes
         end
       end
 
-      def _define_nested_attributes(name, type, form = nil, default: nil, copy_errors: true, attributes_setter: true, **options, &block) # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists
+      def _define_nested_attributes(name, type, form = nil, initial_value: nil, copy_errors: true, attributes_setter: true, **options, &block) # rubocop:disable Metrics/AbcSize, Metrics/ParameterLists, Layout/LineLength
         form = form.constantize if form.is_a? String
         form = Helpers.create_anonymous_form(name, self.name, form, &block) if block_given?
         safe_setter name
         safe_setter "#{name}_attributes" if attributes_setter
         self._nested_attributes = _nested_attributes.merge(name => form)
-        self._attribute_default_procs = _attribute_default_procs.merge(name => default) if default
+        self._attribute_initial_procs = _attribute_initial_procs.merge(name => initial_value) if initial_value
         store = :"_nested_attribute_#{name}"
         _nested_methods.module_eval do
           define_method store do

--- a/lib/strong_attributes/version.rb
+++ b/lib/strong_attributes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StrongAttributes
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/spec/strong_attributes/nested_attributes/nested_array_spec.rb
+++ b/spec/strong_attributes/nested_attributes/nested_array_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedArray do
     expect(test_class.new(people: [name: "foo"]).people.first.class.name).to eq "Person"
   end
 
-  describe "default values" do
-    it "sets fixed defaults" do
+  describe "initial_value" do
+    it "sets fixed initial value" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_array_attributes :array, default: [name: "foo"] do
+        nested_array_attributes :array, initial_value: [name: "foo"] do
           attribute :name, :string
         end
       end
@@ -93,11 +93,11 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedArray do
       )
     end
 
-    it "sets proc defaults" do
+    it "sets initial value from proc" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_array_attributes :array, default: -> { [name: "foo"] } do
+        nested_array_attributes :array, initial_value: -> { [name: "foo"] } do
           attribute :name, :string
         end
       end
@@ -111,11 +111,11 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedArray do
       )
     end
 
-    it "sets method defaults" do
+    it "sets initial value from method" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_array_attributes :array, default: :default_value do
+        nested_array_attributes :array, initial_value: :default_value do
           attribute :name, :string
         end
 
@@ -133,17 +133,20 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedArray do
       )
     end
 
-    it "replaces defaults" do
+    it "merges values into initial values" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_array_attributes :array, default: [name: "foo"] do
+        nested_array_attributes :array, initial_value: [name: "foo"] do
           attribute :name, :string
         end
       end
 
       expect(test_class.new(array: [name: "bar"])).to have_attributes(
         array: match([
+          have_attributes(
+            name: "foo"
+          ),
           have_attributes(
             name: "bar"
           )
@@ -364,7 +367,7 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedArray do
           "Form"
         end
 
-        nested_array_attributes :array, default: [{}] do
+        nested_array_attributes :array, initial_value: [{}] do
           attribute :name, :string
           attribute :number, :float
 
@@ -674,6 +677,27 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedArray do
           have_attributes(name: "foe", height: nil)
         ])
       )
+    end
+
+    context "with a default" do
+      let(:test_class) do
+        Class.new do
+          include StrongAttributes
+
+          nested_array_attributes :array, initial_value: -> { [name: "foo"] }, replace: true do
+            attribute :name, :string
+            attribute :height, :float
+          end
+        end
+      end
+
+      it "replaces attributes" do
+        expect(test_class.new(array: [name: "bar"])).to have_attributes(
+          array: match([
+            have_attributes(name: "bar", height: nil)
+          ])
+        )
+      end
     end
   end
 end

--- a/spec/strong_attributes/nested_attributes/nested_object_spec.rb
+++ b/spec/strong_attributes/nested_attributes/nested_object_spec.rb
@@ -173,12 +173,12 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
     expect(test_class.new(object: { name: "foo" }).object.class.name).to eq "Object"
   end
 
-  describe "default values" do
-    it "sets fixed defaults" do
+  describe "initial values" do
+    it "sets fixed initial values" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_attributes :object, default: { name: "foo" } do
+        nested_attributes :object, initial_value: { name: "foo" } do
           attribute :name, :string
         end
       end
@@ -190,11 +190,11 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
       )
     end
 
-    it "sets proc defaults" do
+    it "sets initial values by proc" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_attributes :object, default: -> { { name: "foo" } } do
+        nested_attributes :object, initial_value: -> { { name: "foo" } } do
           attribute :name, :string
         end
       end
@@ -206,11 +206,11 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
       )
     end
 
-    it "sets method defaults" do
+    it "sets initial value by method" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_attributes :object, default: :default_value do
+        nested_attributes :object, initial_value: :default_value do
           attribute :name, :string
         end
 
@@ -226,11 +226,11 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
       )
     end
 
-    it "replaces default" do
+    it "merges values into the initial value" do
       test_class = Class.new do
         include StrongAttributes
 
-        nested_attributes :object, default: { name: "foo" } do
+        nested_attributes :object, initial_value: { name: "foo" } do
           attribute :name, :string
           attribute :number, :float
         end
@@ -238,7 +238,8 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
 
       expect(test_class.new(object: { number: 1 })).to have_attributes(
         object: have_attributes(
-          number: 1.0
+          number: 1.0,
+          name: "foo"
         )
       )
     end
@@ -342,7 +343,7 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
           "Form"
         end
 
-        nested_attributes :object, default: {} do
+        nested_attributes :object, initial_value: {} do
           attribute :name, :string
           attribute :number, :float
 
@@ -367,7 +368,7 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
             "Form"
           end
 
-          nested_attributes :object, default: {}, copy_errors: false do
+          nested_attributes :object, initial_value: {}, copy_errors: false do
             attribute :name, :string
             attribute :number, :float
 
@@ -389,7 +390,7 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
             "Class"
           end
 
-          nested_attributes :object, default: {}, copy_errors: false do
+          nested_attributes :object, initial_value: {}, copy_errors: false do
             attribute :name, :string
             validates :name, presence: true
           end
@@ -581,6 +582,25 @@ RSpec.describe StrongAttributes::NestedAttributes::NestedObject do
       expect(test).to have_attributes(
         object: have_attributes(name: "foe", height: nil)
       )
+    end
+
+    context "with an initial value" do
+      let(:test_class) do
+        Class.new do
+          include StrongAttributes
+
+          nested_attributes :object, replace: true, initial_value: -> { { name: "foo" } } do
+            attribute :name, :string
+            attribute :height, :float
+          end
+        end
+      end
+
+      it "replaces the initial value" do
+        expect(test_class.new(object: { height: 1 })).to have_attributes(
+          object: have_attributes(name: nil, height: 1)
+        )
+      end
     end
   end
 end

--- a/spec/strong_attributes_spec.rb
+++ b/spec/strong_attributes_spec.rb
@@ -199,6 +199,38 @@ RSpec.describe StrongAttributes do
         unsafe: nil
       )
     end
+
+    context "with an already set attribute" do
+      it "is not replaced by the default" do
+        test_class = Class.new do
+          include StrongAttributes
+
+          safe_setter :complex_setter
+
+          attribute :foo, :string, default: "foo"
+          attribute :bar, :string, default: -> { "bar" }
+          attribute :fee, :boolean, default: -> { true }
+
+          def complex_setter=(value)
+            self.foo = value
+            self.bar = value
+            self.fee = false
+          end
+        end
+
+        expect(test_class.new).to have_attributes(
+          foo: "foo",
+          bar: "bar",
+          fee: true
+        )
+
+        expect(test_class.new(complex_setter: "fizz")).to have_attributes(
+          foo: "fizz",
+          bar: "fizz",
+          fee: false
+        )
+      end
+    end
   end
 
   describe "setting attributes with defaults" do


### PR DESCRIPTION
Nested attributes previously took a `default`.  Version 0.0.10 changed the initialization order so proc defaults were set after attribute values are set.

This made it really hard to set initial values for nested attributes if you wanted the user values to be merged in.

Now nested attributes take a `initial_value` instead of `default`.